### PR TITLE
Invalid Payload Error Fix

### DIFF
--- a/src/EmailDirect/Subscribers.php
+++ b/src/EmailDirect/Subscribers.php
@@ -57,7 +57,7 @@ class EmailDirect_Subscribers extends EmailDirect_Resource
      */
     public function create($email, $data = array())
     {
-        $data = array_merge($data, array(
+        $data = array_merge(array($data), array(
             'EmailAddress' => $email
         ));
         return $this->_adapter->post('/Subscribers', $data);


### PR DESCRIPTION
When adding the Custom Fields array in the $data array, it needed to be
wrapped in an additional array in order for the json_encode to work
later in the Adapter.  See issue discussed here:
http://stackoverflow.com/questions/15559735/no-square-bracket-json-array
